### PR TITLE
Fix sync.trigger arguments passthrough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 6.1.2
+- Sync helpers now properly pass through arguments.
+ 
 ### 6.1.1
 - Expose helper/sync to support custom sync handlers.
  

--- a/dist/backbone-crux.js
+++ b/dist/backbone-crux.js
@@ -237,11 +237,12 @@
       },
       trigger: function trigger(model, triggerStr) {
           if (model.trigger) {
-              if (triggerStr.match(/success/)) {
-                  model.trigger(triggerStr, arguments.length <= 2 ? undefined : arguments[2]);
-              } else {
-                  model.trigger(triggerStr);
+              for (var _len = arguments.length, args = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
+                  args[_key - 2] = arguments[_key];
               }
+
+              args.unshift(triggerStr);
+              model.trigger.apply(model, args);
           }
       },
       before: function before(model, method) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "backbone-crux",
   "description": "Unmissable patches for Backbone.",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "license": "ISC",
   "author": "Burhan Zainuddin <burhan@codeyellow.nl>",
   "contributors": [

--- a/src/helper/sync.js
+++ b/src/helper/sync.js
@@ -31,9 +31,8 @@ export default {
             return xhr;
         };
     },
-    trigger(model, triggerStr, ...args) {
+    trigger(model, ...args) {
         if (model.trigger) {
-            args.unshift(triggerStr);
             model.trigger.apply(model, args);
         }
     },

--- a/src/helper/sync.js
+++ b/src/helper/sync.js
@@ -33,11 +33,8 @@ export default {
     },
     trigger(model, triggerStr, ...args) {
         if (model.trigger) {
-            if (triggerStr.match(/success/)) {
-                model.trigger(triggerStr, args[0]);
-            } else {
-                model.trigger(triggerStr);
-            }
+            args.unshift(triggerStr);
+            model.trigger.apply(model, args);
         }
     },
     before(model, method) {

--- a/test/sync.js
+++ b/test/sync.js
@@ -14,13 +14,13 @@ test.afterEach(t => {
 
 function okResponse() {
     const d = deferred();
-    d.resolve({ foo: 'bar' });
+    d.resolve('data', 'textStatus', 'jqXhr');
     return d.promise();
 }
 
 function failResponse() {
     const d = deferred();
-    d.reject({ foo: 'baz' });
+    d.reject('jqXhr', 'textStatus', 'errorThrown');
     return d.promise();
 }
 
@@ -36,7 +36,7 @@ test('collection fetch with ok response', t => {
     t.is(spy.callCount, 4);
     t.true(spy.withArgs('before:read').calledOnce);
     t.true(spy.withArgs('after:read').calledOnce);
-    t.true(spy.calledWithExactly('after:read:success', { foo: 'bar' }));
+    t.true(spy.calledWithExactly('after:read:success', 'data', 'textStatus', 'jqXhr'));
     t.true(spy.withArgs('after:read:success').calledOnce);
 });
 
@@ -52,7 +52,7 @@ test('collection fetch with fail response', t => {
     t.is(spy.callCount, 4);
     t.true(spy.withArgs('before:read').calledOnce);
     t.true(spy.withArgs('after:read').calledOnce);
-    t.true(spy.calledWithExactly('after:read:error'));
+    t.true(spy.calledWithExactly('after:read:error', 'jqXhr', 'textStatus', 'errorThrown'));
     t.true(spy.withArgs('after:read:error').calledOnce);
 });
 


### PR DESCRIPTION
`Syc.trigger` didn't properly pass through arguments to `model.trigger`. Should be fixed now. 